### PR TITLE
Bump q router

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,7 +1,7 @@
 /*! m0-start */
 const config = {
     '*.js': ['eslint --fix --color', 'git add'],
-    '*.json': ['prettier --write', 'git add']
+    '*.{json,yml,yaml}': ['prettier --write', 'git add']
 };
 /*! m0-end */
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "q-template-validator",
-    "version": "0.0.3",
+    "version": "1.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-    "name": "q-template-validator ",
-    "version": "0.0.1",
+    "name": "q-template-validator",
+    "version": "0.0.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -203,9 +203,9 @@
             },
             "dependencies": {
                 "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
                     "dev": true
                 }
             }
@@ -856,9 +856,9 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "6.4.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-                    "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+                    "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
                     "dev": true
                 }
             }
@@ -2756,7 +2756,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -2777,12 +2778,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -2797,17 +2800,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -2924,7 +2930,8 @@
                 "inherits": {
                     "version": "2.0.4",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -2936,6 +2943,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -2950,6 +2958,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -2957,12 +2966,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.9.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -2981,6 +2992,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -3070,7 +3082,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -3082,6 +3095,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -3167,7 +3181,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -3203,6 +3218,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -3222,6 +3238,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -3265,12 +3282,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -3374,9 +3393,9 @@
             }
         },
         "globby": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
-            "integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+            "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
             "requires": {
                 "array-union": "^2.1.0",
                 "dir-glob": "^3.0.1",
@@ -5083,9 +5102,9 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "5.7.3",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-                    "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+                    "version": "5.7.4",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+                    "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
                     "dev": true
                 }
             }
@@ -5139,9 +5158,9 @@
             },
             "dependencies": {
                 "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
                     "dev": true
                 }
             }
@@ -5781,9 +5800,9 @@
             }
         },
         "minimist": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
             "dev": true
         },
         "mixin-deep": {
@@ -5808,17 +5827,18 @@
             }
         },
         "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
             "dev": true,
             "requires": {
-                "minimist": "0.0.8"
+                "minimist": "^1.2.5"
             }
         },
         "module-zero": {
-            "version": "github:webstacker/module-zero#22a0fa68b7160fdab0cb2cdf3c266effc11ed39a",
-            "from": "github:webstacker/module-zero#v0.6.1",
+            "version": "github:webstacker/module-zero#3fd45807112efd797792ad0dcda64cc0d064a262",
+            "from": "github:webstacker/module-zero#v0.8.0",
+            "dev": true,
             "requires": {
                 "detect-newline": "^3.1.0",
                 "fs-extra": "^8.1.0",
@@ -6358,17 +6378,18 @@
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         },
         "q-base-config": {
-            "version": "github:CriminalInjuriesCompensationAuthority/q-base-config#422966d36b16ac434497b57451e4bc426e70e36f",
-            "from": "github:CriminalInjuriesCompensationAuthority/q-base-config#v0.6.0",
+            "version": "github:CriminalInjuriesCompensationAuthority/q-base-config#a216f1ace9b37330ca0f957a157dd73f43614bb7",
+            "from": "github:CriminalInjuriesCompensationAuthority/q-base-config#v0.9.0",
+            "dev": true,
             "requires": {
-                "module-zero": "github:webstacker/module-zero#22a0fa68b7160fdab0cb2cdf3c266effc11ed39a"
+                "module-zero": "github:webstacker/module-zero#v0.8.0"
             }
         },
         "q-router": {
             "version": "github:CriminalInjuriesCompensationAuthority/q-router#5f64e1645797f59c8d9eb672f9f426d0d3dbd27c",
             "from": "github:CriminalInjuriesCompensationAuthority/q-router#v2.4.0",
             "requires": {
-                "json-rules": "git+https://github.com/webstacker/json-rules.git#794d98f1a42316c4e62c2efe76bcb9be8a2944d7",
+                "json-rules": "git+https://github.com/webstacker/json-rules.git",
                 "moment": "^2.24.0"
             }
         },
@@ -6376,7 +6397,26 @@
             "version": "github:CriminalInjuriesCompensationAuthority/q-schema#00f8f0fc404975ac032302d722cd444c6e597852",
             "from": "github:CriminalInjuriesCompensationAuthority/q-schema#v1.0.0",
             "requires": {
-                "q-base-config": "github:CriminalInjuriesCompensationAuthority/q-base-config#422966d36b16ac434497b57451e4bc426e70e36f"
+                "q-base-config": "github:CriminalInjuriesCompensationAuthority/q-base-config#v0.6.0"
+            },
+            "dependencies": {
+                "module-zero": {
+                    "version": "github:webstacker/module-zero#22a0fa68b7160fdab0cb2cdf3c266effc11ed39a",
+                    "from": "github:webstacker/module-zero#v0.6.1",
+                    "requires": {
+                        "detect-newline": "^3.1.0",
+                        "fs-extra": "^8.1.0",
+                        "globby": "^11.0.0",
+                        "write-pkg": "^4.0.0"
+                    }
+                },
+                "q-base-config": {
+                    "version": "github:CriminalInjuriesCompensationAuthority/q-base-config#422966d36b16ac434497b57451e4bc426e70e36f",
+                    "from": "github:CriminalInjuriesCompensationAuthority/q-base-config#v0.6.0",
+                    "requires": {
+                        "module-zero": "github:webstacker/module-zero#v0.6.1"
+                    }
+                }
             }
         },
         "qs": {
@@ -6767,9 +6807,9 @@
                     }
                 },
                 "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
                     "dev": true
                 },
                 "to-regex-range": {
@@ -8002,9 +8042,9 @@
             }
         },
         "yargs-parser": {
-            "version": "13.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-            "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+            "version": "13.1.2",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+            "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
             "dev": true,
             "requires": {
                 "camelcase": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5122,8 +5122,8 @@
             "dev": true
         },
         "json-rules": {
-            "version": "git+https://github.com/webstacker/json-rules.git#794d98f1a42316c4e62c2efe76bcb9be8a2944d7",
-            "from": "git+https://github.com/webstacker/json-rules.git"
+            "version": "github:webstacker/json-rules#ea09a0ae33437b985d20af683577a5a1f31d834a",
+            "from": "github:webstacker/json-rules#v0.3.0"
         },
         "json-schema": {
             "version": "0.2.3",
@@ -5847,9 +5847,9 @@
             }
         },
         "moment": {
-            "version": "2.24.0",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-            "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+            "version": "2.27.0",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+            "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
         },
         "ms": {
             "version": "2.1.2",
@@ -6386,10 +6386,10 @@
             }
         },
         "q-router": {
-            "version": "github:CriminalInjuriesCompensationAuthority/q-router#5f64e1645797f59c8d9eb672f9f426d0d3dbd27c",
-            "from": "github:CriminalInjuriesCompensationAuthority/q-router#v2.4.0",
+            "version": "github:CriminalInjuriesCompensationAuthority/q-router#6ec5a28346bd5d3882b421edf0df6fdad137b123",
+            "from": "github:CriminalInjuriesCompensationAuthority/q-router#v2.5.0",
             "requires": {
-                "json-rules": "git+https://github.com/webstacker/json-rules.git",
+                "json-rules": "github:webstacker/json-rules#v0.3.0",
                 "moment": "^2.24.0"
             }
         },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,29 @@
     },
     "author": "CICA",
     "license": "MIT",
+    "devDependencies": {
+        "eslint": "^6.8.0",
+        "eslint-config-airbnb-base": "^14.0.0",
+        "eslint-config-prettier": "^6.9.0",
+        "eslint-plugin-import": "^2.19.1",
+        "eslint-plugin-jest": "^23.3.0",
+        "eslint-plugin-prettier": "^3.1.2",
+        "fs-extra": "^8.1.0",
+        "husky": "^4.0.3",
+        "jest": "^24.9.0",
+        "jest-extended": "^0.11.5",
+        "lint-staged": "^9.5.0",
+        "prettier": "^1.19.1",
+        "q-base-config": "github:CriminalInjuriesCompensationAuthority/q-base-config#v0.9.0"
+    },
+    "dependencies": {
+        "ajv": "^6.12.0",
+        "ajv-errors": "^1.0.1",
+        "lodash.get": "^4.4.2",
+        "lodash.has": "^4.5.2",
+        "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#v2.4.0",
+        "q-schema": "github:CriminalInjuriesCompensationAuthority/q-schema#v1.0.0"
+    },
     "_m0": {
         "devDependencies": {
             "eslint": "^6.8.0",
@@ -31,36 +54,13 @@
             ".huskyrc.js",
             ".lintstagedrc.js",
             ".prettierrc.js",
-            "jest.config.js",
-            ".gitignore"
+            ".gitignore",
+            "jest.config.js"
         ],
         "files": [
             ".editorconfig",
             "LICENSE",
             "stuff/____README____"
         ]
-    },
-    "devDependencies": {
-        "eslint": "^6.8.0",
-        "eslint-config-airbnb-base": "^14.0.0",
-        "eslint-config-prettier": "^6.9.0",
-        "eslint-plugin-import": "^2.19.1",
-        "eslint-plugin-jest": "^23.3.0",
-        "eslint-plugin-prettier": "^3.1.2",
-        "fs-extra": "^8.1.0",
-        "husky": "^4.0.3",
-        "jest": "^24.9.0",
-        "jest-extended": "^0.11.5",
-        "lint-staged": "^9.5.0",
-        "prettier": "^1.19.1",
-        "q-base-config": "github:CriminalInjuriesCompensationAuthority/q-base-config#v0.6.0"
-    },
-    "dependencies": {
-        "ajv": "^6.12.0",
-        "ajv-errors": "^1.0.1",
-        "lodash.get": "^4.4.2",
-        "lodash.has": "^4.5.2",
-        "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#v2.4.0",
-        "q-schema": "github:CriminalInjuriesCompensationAuthority/q-schema#v1.0.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "ajv-errors": "^1.0.1",
         "lodash.get": "^4.4.2",
         "lodash.has": "^4.5.2",
-        "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#v2.4.0",
+        "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#v2.5.0",
         "q-schema": "github:CriminalInjuriesCompensationAuthority/q-schema#v1.0.0"
     },
     "_m0": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "q-template-validator",
-    "version": "0.0.3",
+    "version": "1.0.0",
     "description": "Ensure questionnaire templates are valid",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
* This bumps the q-router to the latest version which allows the testing of routes that use "includes" when working with answer arrays.
* Bumps q-base-config to address some module security issues.
* Bumps this module to v1.0.0 as it's now used for production purposes. This also fixes the previous incorrect version number that was using patch incorrectly.

