### PR TITLE
Bump q-router to 2.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5143,8 +5143,8 @@
             "dev": true
         },
         "json-rules": {
-            "version": "github:webstacker/json-rules#ea09a0ae33437b985d20af683577a5a1f31d834a",
-            "from": "github:webstacker/json-rules#v0.3.0"
+            "version": "github:CriminalInjuriesCompensationAuthority/json-rules#ba378d44602e68dbee87c1b9a534b0fc65ad9396",
+            "from": "github:CriminalInjuriesCompensationAuthority/json-rules#v1.0.0"
         },
         "json-schema": {
             "version": "0.2.3",
@@ -5872,9 +5872,9 @@
             }
         },
         "moment": {
-            "version": "2.27.0",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-            "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
+            "version": "2.29.1",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+            "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
         },
         "ms": {
             "version": "2.1.2",
@@ -6414,10 +6414,10 @@
             }
         },
         "q-router": {
-            "version": "github:CriminalInjuriesCompensationAuthority/q-router#6ec5a28346bd5d3882b421edf0df6fdad137b123",
-            "from": "github:CriminalInjuriesCompensationAuthority/q-router#v2.5.0",
+            "version": "github:CriminalInjuriesCompensationAuthority/q-router#2228f9f134ae5bde840573b6966e0bcf8678ebb5",
+            "from": "github:CriminalInjuriesCompensationAuthority/q-router#v2.5.3",
             "requires": {
-                "json-rules": "github:webstacker/json-rules#v0.3.0",
+                "json-rules": "github:CriminalInjuriesCompensationAuthority/json-rules#v1.0.0",
                 "moment": "^2.24.0"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "q-template-validator",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "q-template-validator",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Ensure questionnaire templates are valid",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "ajv-errors": "^1.0.1",
         "lodash.get": "^4.4.2",
         "lodash.has": "^4.5.2",
-        "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#v2.5.0",
+        "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#v2.5.3",
         "q-schema": "github:CriminalInjuriesCompensationAuthority/q-schema#v1.0.1"
     },
     "_m0": {


### PR DESCRIPTION
Update to [latest version of q-router](https://github.com/CriminalInjuriesCompensationAuthority/q-router/releases/tag/v2.5.3).  All tests passing.