### PR TITLE
Improve cond data ref check

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,7 +192,7 @@ function createQuestionnaireTemplateHelper({
             const conditions = getAllConditions(state);
 
             conditions.forEach(condition => {
-                condition.elements.forEach((element, elementIndex) => {
+                condition.elements.forEach(element => {
                     if (isDataReference(element)) {
                         const dataReferenceParts = element.split('.');
                         const dataReference = `${dataReferenceParts[2]}.schema.properties.${dataReferenceParts[3]}`;
@@ -200,7 +200,7 @@ function createQuestionnaireTemplateHelper({
                         if (_.has(sections, dataReference) === false) {
                             acc.push({
                                 type: 'ConditionDataReferenceNotFound',
-                                source: `/routes/states/${stateId}/on/ANSWER/${condition.arrayIndex}/cond/${elementIndex}`,
+                                source: `/routes/states/${stateId}/on/ANSWER/${condition.arrayIndex}/cond`,
                                 description: `Condition data reference '/sections/${dataReference.replace(
                                     /\./g,
                                     '/'

--- a/index.test.js
+++ b/index.test.js
@@ -342,7 +342,7 @@ describe('q-template-validator', () => {
                 {
                     type: 'ConditionDataReferenceNotFound',
                     source:
-                        '/routes/states/p-applicant-british-citizen-or-eu-national/on/ANSWER/0/cond/1',
+                        '/routes/states/p-applicant-british-citizen-or-eu-national/on/ANSWER/0/cond',
                     description:
                         "Condition data reference '/sections/p-foo/schema/properties/q-baz' not found"
                 }
@@ -995,7 +995,7 @@ describe('q-template-validator', () => {
                 {
                     type: 'ConditionDataReferenceNotFound',
                     source:
-                        '/routes/states/p-applicant-british-citizen-or-eu-national/on/ANSWER/0/cond/1',
+                        '/routes/states/p-applicant-british-citizen-or-eu-national/on/ANSWER/0/cond',
                     description:
                         "Condition data reference '/sections/p-foo/schema/properties/q-baz' not found"
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "q-template-validator",
-    "version": "5.3.0",
+    "version": "5.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "q-template-validator",
-            "version": "5.3.0",
+            "version": "5.4.0",
             "license": "MIT",
             "dependencies": {
                 "ajv": "^6.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "q-template-validator",
-    "version": "5.3.0",
+    "version": "5.4.0",
     "description": "Ensure questionnaire templates are valid",
     "main": "index.js",
     "engines": {

--- a/utils/getDataRefsFromJsonExpression/index.js
+++ b/utils/getDataRefsFromJsonExpression/index.js
@@ -1,0 +1,23 @@
+'use strict';
+
+function isDataReference(element) {
+    return typeof element === 'string' && element.startsWith('$.');
+}
+
+function getDataRefsFromJsonExpression(jsonExpression) {
+    const dataRefs = [];
+
+    jsonExpression.forEach(element => {
+        if (isDataReference(element)) {
+            dataRefs.push(element);
+        }
+
+        if (Array.isArray(element)) {
+            dataRefs.push(getDataRefsFromJsonExpression(element));
+        }
+    });
+
+    return dataRefs.flat();
+}
+
+module.exports = getDataRefsFromJsonExpression;

--- a/utils/getDataRefsFromJsonExpression/index.test.js
+++ b/utils/getDataRefsFromJsonExpression/index.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const getDataRefsFromJsonExpression = require('./index');
+
+describe('getDataRefsFromJsonExpression', () => {
+    it('should return an empty array when no refs exist', () => {
+        const jsonExpression = ['==', 1, 2];
+        const dataRefs = getDataRefsFromJsonExpression(jsonExpression);
+
+        expect(dataRefs).toEqual([]);
+    });
+
+    it('should return ref(s) for a flat expression', () => {
+        const jsonExpression = ['==', '$.some.ref', 1, 'foo', '$.some.other.ref', null];
+        const dataRefs = getDataRefsFromJsonExpression(jsonExpression);
+
+        expect(dataRefs).toEqual(['$.some.ref', '$.some.other.ref']);
+    });
+
+    it('should return ref(s) for nested expressions', () => {
+        const jsonExpression = [
+            'and',
+            ['==', '$.some.refA', 1, 'foo', '$.some.refB', null],
+            [
+                'or',
+                ['==', '$.some.refC', 1, 'foo', '$.some.refD', null],
+                ['==', '$.some.refE', ['==', '$.some.refF', 1, 'foo', '$.some.refG', null]]
+            ]
+        ];
+        const dataRefs = getDataRefsFromJsonExpression(jsonExpression);
+
+        expect(dataRefs).toEqual([
+            '$.some.refA',
+            '$.some.refB',
+            '$.some.refC',
+            '$.some.refD',
+            '$.some.refE',
+            '$.some.refF',
+            '$.some.refG'
+        ]);
+    });
+});


### PR DESCRIPTION
The current `ensureAllConditionDataReferencesHaveCorrespondingQuestion` function only checks flat JSON Expressions e.g.

`['==', '$.some.data.ref', 'foo']`

This PR ensures nested expressions are also tested e.g.

`['and', ['==', 1, 1], ['==', '$some.nested.data.ref', 'bar']]`