### PR TITLE
Check routes are satisfiable

### DIFF
--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,7 +1,7 @@
 /*! m0-start */
 const config = {
     hooks: {
-        //'pre-commit': 'lint-staged'
+        'pre-commit': 'lint-staged'
     }
 };
 /*! m0-end */

--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,7 +1,7 @@
 /*! m0-start */
 const config = {
     hooks: {
-        'pre-commit': 'lint-staged'
+        //'pre-commit': 'lint-staged'
     }
 };
 /*! m0-end */
@@ -9,4 +9,3 @@ const config = {
 /*! m0-start */
 module.exports = config;
 /*! m0-end */
-

--- a/validators/ensureAllConditionsAreSatisfiable/fixtures/questionnaire-schema-roles.js
+++ b/validators/ensureAllConditionsAreSatisfiable/fixtures/questionnaire-schema-roles.js
@@ -1,0 +1,244 @@
+module.exports = {
+    attributes: {
+        q__roles: {
+            proxy: {
+                schema: {
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    title: 'A type of proxy for the applicant e.g. mainapplicant, rep',
+                    type: 'boolean',
+                    // prettier-ignore
+                    const: ['==',
+                        '$.answers.p-applicant-who-are-you-applying-for.q-applicant-who-are-you-applying-for',
+                        'someone-else'
+                    ],
+                    examples: [{}],
+                    invalidExamples: [{}]
+                }
+            },
+            myself: {
+                schema: {
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    title: 'Myself journey role',
+                    type: 'boolean',
+                    // prettier-ignore
+                    const: ['==',
+                        '$.answers.p-applicant-who-are-you-applying-for.q-applicant-who-are-you-applying-for',
+                        'myself'
+                    ],
+                    examples: [{}],
+                    invalidExamples: [{}]
+                }
+            },
+            child: {
+                schema: {
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    title: 'Child applicant role',
+                    type: 'boolean',
+                    // prettier-ignore
+                    const: ['==',
+                    '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over',
+                    false
+                    ],
+                    examples: [{}],
+                    invalidExamples: [{}]
+                }
+            },
+            adult: {
+                schema: {
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    title: 'Adult applicant role',
+                    type: 'boolean',
+                    // prettier-ignore
+                    const: ['==',
+                    '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over',
+                    true
+                    ],
+                    examples: [{}],
+                    invalidExamples: [{}]
+                }
+            },
+            mainapplicant: {
+                schema: {
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    title: 'Main Applicant role',
+                    type: 'boolean',
+                    // prettier-ignore
+                    const: ['or',
+                        ['==', '$.answers.p-mainapplicant-parent.q-mainapplicant-parent', true],
+                        ['==', '$.answers.p--has-legal-authority.q--has-legal-authority', true]
+                    ],
+                    examples: [{}],
+                    invalidExamples: [{}]
+                }
+            },
+            rep: {
+                schema: {
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    title: 'Rep role',
+                    type: 'boolean',
+                    // prettier-ignore
+                    const: ['or',
+                        [
+                            'and',
+                            ['==', '$.answers.p-applicant-who-are-you-applying-for.q-applicant-who-are-you-applying-for', 'someone-else'],
+                            ['==', '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over', false],
+                            ['==', '$.answers.p-mainapplicant-parent.q-mainapplicant-parent', false],
+                            ['==', '$.answers.p--has-legal-authority.q--has-legal-authority', false]
+                        ],
+                        [
+                            'and',
+                            ['==', '$.answers.p-applicant-who-are-you-applying-for.q-applicant-who-are-you-applying-for', 'someone-else'],
+                            ['==', '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over', true],
+                            ['==', '$.answers.p--has-legal-authority.q--has-legal-authority', false],
+                            ['==', '$.answers.p--represents-legal-authority.q--represents-legal-authority', true]
+                        ],
+                        [
+                            'and',
+                            ['==', '$.answers.p-applicant-who-are-you-applying-for.q-applicant-who-are-you-applying-for', 'someone-else'],
+                            ['==', '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over', true],
+                            ['==', '$.answers.p--has-legal-authority.q--has-legal-authority', false],
+                            ['==', '$.answers.p--represents-legal-authority.q--represents-legal-authority', false]
+                        ],
+                        [
+                            'and',
+                            ['==', '$.answers.p-applicant-who-are-you-applying-for.q-applicant-who-are-you-applying-for', 'someone-else'],
+                            ['==', '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over', true],
+                            ['==', '$.answers.p-applicant-can-handle-affairs.q-applicant-capable', true]
+                        ]
+                    ],
+                    examples: [{}],
+                    invalidExamples: [{}]
+                }
+            },
+            noauthority: {
+                schema: {
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    title: 'no authority role',
+                    type: 'boolean',
+                    // prettier-ignore
+                    const:
+                        ['and',
+                            ['==', '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over', true],
+                            ['==', '$.answers.p-applicant-can-handle-affairs.q-applicant-capable', false],
+                            ['==', '$.answers.p--has-legal-authority.q--has-legal-authority', false],
+                            ['==', '$.answers.p--represents-legal-authority.q--represents-legal-authority', false]
+                        ],
+                    examples: [{}],
+                    invalidExamples: [{}]
+                }
+            },
+            incapable: {
+                schema: {
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    title: 'incapable role',
+                    type: 'boolean',
+                    // prettier-ignore
+                    const:  ['==', '$.answers.p-applicant-can-handle-affairs.q-applicant-capable', false],
+                    examples: [{}],
+                    invalidExamples: [{}]
+                }
+            },
+            capable: {
+                schema: {
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    title: 'capable role',
+                    type: 'boolean',
+                    // prettier-ignore
+                    const: ['or',
+                        ['==', '$.answers.p-applicant-can-handle-affairs.q-applicant-capable', true],
+                        ['==', '$.answers.p-applicant-who-are-you-applying-for.q-applicant-who-are-you-applying-for', 'myself']
+                    ],
+                    examples: [{}],
+                    invalidExamples: [{}]
+                }
+            },
+            authority: {
+                schema: {
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    title: 'Legal authority role',
+                    type: 'boolean',
+                    // prettier-ignore
+                    const: ['or',
+                        ['==', '$.answers.p--has-legal-authority.q--has-legal-authority', true],
+                        ['==', '$.answers.p--represents-legal-authority.q--represents-legal-authority', true]
+                    ],
+                    examples: [true, false],
+                    invalidExamples: [{}]
+                }
+            },
+            deceased: {
+                schema: {
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    title: 'Deceased role',
+                    type: 'boolean',
+                    // prettier-ignore
+                    const: ['==', '$.answers.p-applicant-fatal-claim.q-applicant-fatal-claim', true],
+                    examples: [true, false],
+                    invalidExamples: [{}]
+                }
+            },
+            nonDeceased: {
+                schema: {
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    title: 'Non Deceased journey role',
+                    type: 'boolean',
+                    // prettier-ignore
+                    const: ['==', '$.answers.p-applicant-fatal-claim.q-applicant-fatal-claim', false],
+                    examples: [true, false],
+                    invalidExamples: [{}]
+                }
+            },
+            childUnder12: {
+                schema: {
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    title: 'child under the age of 12',
+                    type: 'boolean',
+                    // prettier-ignore
+                    const: [
+                        'dateCompare',
+                        '$.answers.p-applicant-enter-your-date-of-birth.q-applicant-enter-your-date-of-birth', // this date ...
+                        '<', // is less than ...
+                        '-12', // 12 ...
+                        'years' // years (before, due to the negative (-12) ...
+                        // today's date (no second date given. defaults to today's date).
+                    ],
+                    examples: [{}],
+                    invalidExamples: [{}]
+                }
+            },
+            childOver12: {
+                schema: {
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    title: 'child over the age of 12',
+                    type: 'boolean',
+                    // prettier-ignore
+                    const:   [
+                        'dateCompare',
+                        '$.answers.p-applicant-enter-your-date-of-birth.q-applicant-enter-your-date-of-birth', // this date ...
+                        '>=', // is greater than or equeal too ...
+                        '-12', // 12 ...
+                        'years' // years (before, due to the negative (-12) ...
+                        // today's date (no second date given. defaults to today's date).
+                    ],
+                    examples: [{}],
+                    invalidExamples: [{}]
+                }
+            },
+            noContactMethod: {
+                schema: {
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    title: 'has no email or text contact method',
+                    type: 'boolean',
+                    // prettier-ignore
+                    const: ['or',
+                        ['==', '$.answers.p-applicant-confirmation-method.q-applicant-confirmation-method', 'none'],
+                        ['==', '$.answers.p-mainapplicant-confirmation-method.q-mainapplicant-confirmation-method', 'none'],
+                        ['==', '$.answers.p-rep-confirmation-method.q-rep-confirmation-method', 'none']
+                    ],
+                    examples: [{}],
+                    invalidExamples: [{}]
+                }
+            }
+        }
+    }
+};

--- a/validators/ensureAllConditionsAreSatisfiable/fixtures/questionnaire-schema-roles.js
+++ b/validators/ensureAllConditionsAreSatisfiable/fixtures/questionnaire-schema-roles.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
     attributes: {
         q__roles: {

--- a/validators/ensureAllConditionsAreSatisfiable/index.js
+++ b/validators/ensureAllConditionsAreSatisfiable/index.js
@@ -1,0 +1,698 @@
+'use strict';
+
+// assumes routing logic is sound (i.e. there are no conditions like go to page a if question 1 = true and question 1 = false)
+// also assumes that there are no duplicate conditional routes on a page (ors are fine but not multiple route objects with the same target)
+
+// assumes that satisfiability/matching can only happen for the same question via the same method except for != and =. For most this is fine
+// e.g. you can't have both an == and an includes condition for the same question, but in theory for dates it could be bad.
+// Currently this is not an issue, but it could be with more complex datecompare and datedifferencegreaterthantwodays conditions
+
+function matches(preconditionAnswer, routeAnswer) {
+    // return true if the answers match (accounting for arrays, dates etc.)
+    // returns false if they conflict
+    // takes in two objects of the form {type, value}
+
+    if (preconditionAnswer.type === '!=' || routeAnswer.type === '!=') {
+        if (preconditionAnswer.type === routeAnswer.type) {
+            return preconditionAnswer.value.some(answer => routeAnswer.value.includes(answer));
+        }
+        // this catches conditions where the route/precondition is a != and the other is an ==
+        return preconditionAnswer.includes(routeAnswer) || routeAnswer.includes(preconditionAnswer);
+    }
+    if (preconditionAnswer.type === 'includes') {
+        // these are always valid - if the route includes a and the target includes b its still reachable just not guaranteed
+        return true;
+    }
+    if (preconditionAnswer.type === '>' && routeAnswer.type === '>') {
+        return preconditionAnswer.value >= routeAnswer.value;
+    }
+    if (preconditionAnswer.type === '<' && routeAnswer.type === '<') {
+        return preconditionAnswer.value <= routeAnswer.value;
+    }
+    if (preconditionAnswer.type === '>' && routeAnswer.type === '<') {
+        return preconditionAnswer.value < routeAnswer.value;
+    }
+    if (preconditionAnswer.type === '<' && routeAnswer.type === '>') {
+        return preconditionAnswer.value > routeAnswer.value;
+    }
+    return preconditionAnswer.value === routeAnswer.value;
+}
+
+function satisfies(precondition, route) {
+    // Precondition and route are both answers objects
+    // if a precondition satisfies the route completely return 'full'
+    // if a precondition satisfies the route assuming other questions have some value return 'partial'
+    // if a precondition doesn't satisfy a route return 'none'
+    const satisfaction = Object.keys(route).map(section => {
+        const questions = route[section];
+        const matchedQuestions = Object.keys(questions).map(question => {
+            if (precondition?.[section]?.[question] !== undefined) {
+                return matches(precondition[section][question], route[section][question]);
+            }
+            return undefined;
+        });
+        if (matchedQuestions.every(result => result === true)) {
+            return true;
+        }
+        if (matchedQuestions.some(result => result === false)) {
+            return false;
+        }
+        return undefined;
+    });
+    if (satisfaction.every(result => result === true)) {
+        return 'full';
+    }
+    if (satisfaction.some(result => result === false)) {
+        return 'none';
+    }
+    return 'partial';
+}
+
+function getAllRoleDefinitions(template) {
+    const roles = template.attributes.q__roles;
+    const roleDefinitions = {};
+    Object.keys(roles).forEach(role => {
+        roleDefinitions[role] = roles[role].schema.const;
+    });
+
+    return roleDefinitions;
+}
+
+function getPreviousSections(section, template) {
+    // TODO: we may want to add the ability to skip certain sections here, e.g. injury sections
+    const {states} = template.routes;
+    const previousSections = [];
+    Object.keys(states).forEach(state => {
+        if (states[state].type === 'final') {
+            // final states lead to no other states
+        } else if (states[state].on.ANSWER.filter(route => route.target === section).length > 0) {
+            previousSections.push(state);
+        }
+    });
+    return previousSections;
+}
+
+function setSimpleCondition(condition) {
+    // TODO: Currently, all datecompares in the template are based on today's date and time differences of years before now. That is assumed to be the case here.
+    // going forwards all this logic should be handled by an equivalent version of q-expressions/JSON-rules that sets instead of evaluating
+    if (condition[0] === 'includes') {
+        // TODO: This currently only works for single item inclusivity checks, need to check if that is ok
+        const answers = {};
+        const page = condition[1].split('.')[2];
+        const question = condition[1].split('.')[3];
+        answers[page] = {};
+        answers[page][question] = {type: condition[0], value: [condition[2]]};
+        return answers;
+    }
+    if (condition[0] === 'dateCompare') {
+        // going forwards, we could replace this logic to have the answers object be {page-id:{question-id:{type:x, value:y}}}
+        const answers = {};
+        const page = condition[1].split('.')[2];
+        const question = condition[1].split('.')[3];
+        answers[page] = {};
+        if (condition[2] === '>=') {
+            answers[page][question] = {type: '>', value: parseint(condition[3]) + 1};
+        } else if (condition[2] === '<=') {
+            answers[page][question] = {type: '<', value: parseint(condition[3]) - 1};
+        } else {
+            answers[page][question] = {type: condition[2], value: condition[3]};
+        }
+        return answers;
+    }
+    if (condition[0] === 'dateDifferenceGreaterThanTwoDays') {
+        const answers = {};
+        // TODO: make this work
+        const oldPage = condition[2].split('.')[2];
+        const oldQuestion = condition[2].split('.')[3];
+        const newPage = condition[1].split('.')[2];
+        const newQuestion = condition[1].split('.')[3];
+        answers[oldPage] = {};
+        answers[oldPage][oldQuestion] = Date.now() - 50 * 3600 * 1000;
+        answers[newPage] = {};
+        answers[newPage][newQuestion] = Date.now();
+        // return answers;
+    } else if (condition[0] === '!=') {
+        const answers = {};
+        const page = `${condition[1].split('.')[2]}!=${condition[1].split('.')[3]}!=${
+            condition[2]
+        }`;
+        answers[page] = {};
+        return answers;
+    } else {
+        const answers = {};
+        const page = condition[1].split('.')[2];
+        const question = condition[1].split('.')[3];
+        answers[page] = {};
+        answers[page][question] = {type: condition[0], value: condition[2]};
+        return answers;
+    }
+}
+
+function expandConditionExpression(condition, roles) {
+    if (condition[0] === 'or') {
+        condition.shift();
+        const expandedExpression = condition.map(subCondition => {
+            return expandConditionExpression(subCondition, roles);
+        });
+        return {or: expandedExpression};
+    }
+    if (condition[0] === 'and') {
+        const answers = {};
+        condition.shift();
+        return condition.reduce((answers, subCondition) => {
+            return {...answers, ...expandConditionExpression(subCondition, roles)};
+        }, answers);
+    }
+    if (condition[0] === '|role.all') {
+        condition.shift();
+        const replacedRoles = condition.map(role => {
+            return roles[role];
+        });
+        replacedRoles.unshift('and');
+        return expandConditionExpression(replacedRoles, roles);
+    }
+    return setSimpleCondition(condition);
+}
+
+function splitOrExpressions(expression) {
+    // given a condition expanded using expandConditionExpression, remove all or conditions and split up their constituent parts into distinct objects
+    if (expression.or === undefined) {
+        return expression;
+    }
+    const noOrExpression = {...expression};
+    delete noOrExpression.or;
+    return expression.or.map(subcondition => {
+        return splitOrExpressions({...noOrExpression, ...subcondition});
+    });
+}
+
+function collateNotEqualToConditions(preconditions, template) {
+    // use template to get all possible values to a question. then remove any referenced by the != question leaving an array of allowed values
+    preconditions.forEach(precondition => {
+        Object.keys(precondition).forEach(page => {
+            if (page.includes('!=')) {
+                const pageId = page.split('!=')[0];
+                const questionId = page.split('!=')[1];
+                const value = page.split('!=')[2];
+                delete precondition[page];
+                if (precondition[pageId] === undefined) {
+                    precondition[pageId] = {};
+                }
+                if (precondition[pageId][questionId] === undefined) {
+                    const allValues = template.sections[pageId]?.schema?.properties?.[
+                        questionId
+                    ].oneOf.map(answer => answer.const);
+                    allValues.splice(allValues.indexOf(value), 1);
+                    precondition[pageId][questionId] = {type: '!=', value: allValues};
+                } else {
+                    precondition[pageId][questionId].value.splice(
+                        precondition[pageId][questionId].value.indexOf(value),
+                        1
+                    );
+                }
+            }
+        });
+    });
+    return preconditions;
+}
+
+function getSectionPreconditions(section, template, roles) {
+    // Returns an array of answers objects where each object corresponds to a different route off the page, with ORs split into distinct answers objects
+    if (template.routes.states[section].type === 'final') {
+        // final states lead to no other states
+        return [];
+    }
+    const conditionalRoutes = template.routes.states[section].on.ANSWER.filter(
+        route => route.cond
+    ).map(route => route.cond);
+    if (conditionalRoutes.length < 1) {
+        // if a page has no conditional routing it will always be traversable
+        return [];
+    }
+    const expandedPreconditions = conditionalRoutes
+        .map(condition => splitOrExpressions(expandConditionExpression(condition, roles)))
+        .flat(Infinity);
+
+    const cleanedPreconditions = collateNotEqualToConditions(expandedPreconditions, template);
+
+    if (conditionalRoutes.length === template.routes.states[section].on.ANSWER.length) {
+        // TODO: expandedPreconditions.push(getInverseCondition(expandedPreconditions));
+        // This is a nice to have that goes beyond what our current BDD can do anyway
+        // it would tell us if it is possible to get stuck on a page (i.e. tell us undocumented behaviour)
+        return cleanedPreconditions;
+    }
+    return cleanedPreconditions;
+}
+
+function checkSatisfiability(section, template, precondition, targetSection, roles) {
+    // needs to return the modified precondition if part of it has been shown to work, false if it has failed and the precondition otherwise
+    const newPrecondition = {...precondition};
+    const conditionalRoutes = template.routes.states[section].on.ANSWER.filter(route => route.cond);
+
+    if (conditionalRoutes.length < 1) {
+        // if there are no conditional routes, you can always get to the target regardless of the value of that question
+        delete newPrecondition[section];
+        return newPrecondition;
+    }
+
+    const targetConditionIndex = conditionalRoutes
+        .map(route => route.target)
+        .indexOf(targetSection);
+
+    const routeToTarget = conditionalRoutes[targetConditionIndex];
+
+    // going from top to bottom until you hit the target in the conditions, if a precondition matches but goes to a different page then it is invalid
+    const firstRoutes = conditionalRoutes.filter(
+        route => conditionalRoutes.indexOf(route) < targetConditionIndex
+    );
+    if (firstRoutes.length > 0) {
+        if (firstRoutes.some(route => satisfies(newPrecondition, route, roles) === 'full')) {
+            return false;
+        }
+    }
+
+    const splitRoutesToTarget = collateNotEqualToConditions(
+        [splitOrExpressions(expandConditionExpression(routeToTarget.cond, roles))].flat(Infinity)
+    );
+
+    // the above is now a list of 'answers' objects.
+
+    const satisfiedRoutesToTarget = splitRoutesToTarget.map(route =>
+        satisfies(newPrecondition, route)
+    );
+
+    if (satisfiedRoutesToTarget.some(satisfaction => satisfaction === 'full')) {
+        // if all answers referenced in the route are present in the precondition and they satisfy it is valid (this is an early exit. technically it is unknown but as we assume all previous pages are valid we can assume this one is valid too)
+        return {};
+    }
+    if (satisfiedRoutesToTarget.every(satisfaction => satisfaction === 'none')) {
+        // if there is a direct conflict between route and precondition it is invalid(i.e. assuming all sections not in the precondition evaluate as the route requires, given the precondition the route evaluates to false)
+        return false;
+    }
+    // then if the precondition only references this page and it hasn't already been marked as satisfied then it is valid
+    // TODO: can early exit here by deleting all answers mentioned in the route from the precondition, rather than just the page we are on
+    delete newPrecondition[section];
+    return newPrecondition;
+}
+
+function checkValid(targetSection, template, precondition, roles) {
+    // TODO: if we hit the start of the application but still have preconditions then is something wrong or is it invalid? not sure but probably something wrong
+    console.log(precondition);
+    const previousSections = getPreviousSections(targetSection, template);
+    const valid = previousSections.some(section => {
+        const satisfiability = checkSatisfiability(
+            section,
+            template,
+            precondition,
+            targetSection,
+            roles
+        );
+        if (satisfiability === false) {
+            return false;
+        }
+        if (Object.keys(satisfiability).length === 0) {
+            return true;
+        }
+        return checkValid(section, template, satisfiability, roles);
+    });
+    return valid;
+    // We could make this non-recursive using a queue/stack and then that might make identifying errors easier
+    // Although would it? my initial thought was it might make it easier to see at which particular point the route breaks, but
+    // given there are multiple different routes for a precondition this might not help much
+}
+
+function ensureAllConditionsAreSatisfiable(template) {
+    const roles = getAllRoleDefinitions(template);
+    const result = Object.keys(template.routes.states).every(section => {
+        const preconditions = getSectionPreconditions(section, template, roles).filter(
+            condition => {
+                return Object.keys(condition).every(
+                    conditionSection => conditionSection !== section
+                );
+            }
+        );
+        // TODO: improve how this reports a failed/successful test
+        if (preconditions.length > 0) {
+            const results = preconditions.map(precondition =>
+                checkValid(section, template, precondition, roles)
+            );
+            const unsatisfiedPreconditions = [];
+            results.forEach(precondition => {
+                if (precondition === false) {
+                    unsatisfiedPreconditions.push(
+                        preconditions[precondition.indexOf(precondition)]
+                    );
+                }
+            });
+            if (unsatisfiedPreconditions.length > 0) {
+                throw new Error(
+                    `Unsatisfiable route on /sections/${section}: \n ${JSON.stringify(
+                        unsatisfiedPreconditions,
+                        null,
+                        2
+                    )}`
+                );
+            }
+        }
+        return true;
+    });
+    return result;
+}
+
+// might need to reconsider ors, specifically for roles. for roles some of them probably are unreachable so we may need to do the ors as a proper or
+// for the preconditions this is likely the case. for the routes i think it works fine as is because we do a some not an every
+// we can potentially do this by doing the preconditions a bit differently and managing the ors at that high level? Specifically, ors within a
+// precondition are fine - these should all be satisfiable. But the ors within roles may not be
+// may need to rejig ordering of deconstruction - do roles last so that we can keep them grouped
+// first split ands and ors and any roles that don't have an or as we are currently
+// then replace remaining roles with conditions
+// then replace as before but keep the ors in an array or something
+// then when looping over preconditions we can do a some for the ones with ors in
+// this would also make error reporting clearer (maybe?)
+
+// const template = {
+//     sections: {
+//         'p-applicant-infections': {
+//             schema: {
+//                 $schema: 'http://json-schema.org/draft-07/schema#',
+//                 type: 'object',
+//                 required: ['q-applicant-infections'],
+//                 additionalProperties: false,
+//                 properties: {
+//                     'q-applicant-infections': {
+//                         type: 'string',
+//                         title: 'l10nt:q-applicant-infections.title{?lng,context,ns}',
+//                         oneOf: [
+//                             {
+//                                 title: 'Yes',
+//                                 const: 'yes'
+//                             },
+//                             {
+//                                 title: 'No',
+//                                 const: 'no'
+//                             },
+//                             {
+//                                 title: "I'm not sure",
+//                                 const: 'not-sure'
+//                             }
+//                         ],
+//                         meta: {
+//                             classifications: {
+//                                 theme: 'injuries'
+//                             },
+//                             summary: {
+//                                 title:
+//                                     'l10nt:q-applicant-infections.meta.summary.title{?lng,context,ns}'
+//                             }
+//                         }
+//                     }
+//                 },
+//                 errorMessage: {
+//                     required: {
+//                         'q-applicant-infections':
+//                             'l10nt:q-applicant-infections.error.required{?lng,context,ns}'
+//                     }
+//                 },
+//                 examples: [
+//                     {
+//                         'q-applicant-infections': 'yes'
+//                     },
+//                     {
+//                         'q-applicant-infections': 'no'
+//                     }
+//                 ],
+//                 invalidExamples: [
+//                     {
+//                         'q-applicant-infections': 'foo'
+//                     }
+//                 ]
+//             }
+//         }
+//     },
+//     attributes: {
+//         q__roles: {
+//             proxy: {
+//                 schema: {
+//                     $schema: 'http://json-schema.org/draft-07/schema#',
+//                     title: 'A type of proxy for the applicant e.g. mainapplicant, rep',
+//                     type: 'boolean',
+//                     // prettier-ignore
+//                     const: ['==',
+//                 '$.answers.p-applicant-who-are-you-applying-for.q-applicant-who-are-you-applying-for',
+//                 'someone-else'
+//             ],
+//                     examples: [{}],
+//                     invalidExamples: [{}]
+//                 }
+//             },
+//             myself: {
+//                 schema: {
+//                     $schema: 'http://json-schema.org/draft-07/schema#',
+//                     title: 'Myself journey role',
+//                     type: 'boolean',
+//                     // prettier-ignore
+//                     const: ['==',
+//                 '$.answers.p-applicant-who-are-you-applying-for.q-applicant-who-are-you-applying-for',
+//                 'myself'
+//             ],
+//                     examples: [{}],
+//                     invalidExamples: [{}]
+//                 }
+//             },
+//             child: {
+//                 schema: {
+//                     $schema: 'http://json-schema.org/draft-07/schema#',
+//                     title: 'Child applicant role',
+//                     type: 'boolean',
+//                     // prettier-ignore
+//                     const: ['==',
+//             '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over',
+//             false
+//             ],
+//                     examples: [{}],
+//                     invalidExamples: [{}]
+//                 }
+//             },
+//             adult: {
+//                 schema: {
+//                     $schema: 'http://json-schema.org/draft-07/schema#',
+//                     title: 'Adult applicant role',
+//                     type: 'boolean',
+//                     // prettier-ignore
+//                     const: ['==',
+//             '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over',
+//             true
+//             ],
+//                     examples: [{}],
+//                     invalidExamples: [{}]
+//                 }
+//             },
+//             mainapplicant: {
+//                 schema: {
+//                     $schema: 'http://json-schema.org/draft-07/schema#',
+//                     title: 'Main Applicant role',
+//                     type: 'boolean',
+//                     // prettier-ignore
+//                     const: ['or',
+//                 ['==', '$.answers.p-mainapplicant-parent.q-mainapplicant-parent', true],
+//                 ['==', '$.answers.p--has-legal-authority.q--has-legal-authority', true]
+//             ],
+//                     examples: [{}],
+//                     invalidExamples: [{}]
+//                 }
+//             },
+//             rep: {
+//                 schema: {
+//                     $schema: 'http://json-schema.org/draft-07/schema#',
+//                     title: 'Rep role',
+//                     type: 'boolean',
+//                     // prettier-ignore
+//                     const: ['or',
+//                 [
+//                     'and',
+//                     ['==', '$.answers.p-applicant-who-are-you-applying-for.q-applicant-who-are-you-applying-for', 'someone-else'],
+//                     ['==', '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over', false],
+//                     ['==', '$.answers.p-mainapplicant-parent.q-mainapplicant-parent', false],
+//                     ['==', '$.answers.p--has-legal-authority.q--has-legal-authority', false]
+//                 ],
+//                 [
+//                     'and',
+//                     ['==', '$.answers.p-applicant-who-are-you-applying-for.q-applicant-who-are-you-applying-for', 'someone-else'],
+//                     ['==', '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over', true],
+//                     ['==', '$.answers.p--has-legal-authority.q--has-legal-authority', false],
+//                     ['==', '$.answers.p--represents-legal-authority.q--represents-legal-authority', true]
+//                 ],
+//                 [
+//                     'and',
+//                     ['==', '$.answers.p-applicant-who-are-you-applying-for.q-applicant-who-are-you-applying-for', 'someone-else'],
+//                     ['==', '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over', true],
+//                     ['==', '$.answers.p--has-legal-authority.q--has-legal-authority', false],
+//                     ['==', '$.answers.p--represents-legal-authority.q--represents-legal-authority', false]
+//                 ],
+//                 [
+//                     'and',
+//                     ['==', '$.answers.p-applicant-who-are-you-applying-for.q-applicant-who-are-you-applying-for', 'someone-else'],
+//                     ['==', '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over', true],
+//                     ['==', '$.answers.p-applicant-can-handle-affairs.q-applicant-capable', true]
+//                 ]
+//             ],
+//                     examples: [{}],
+//                     invalidExamples: [{}]
+//                 }
+//             },
+//             noauthority: {
+//                 schema: {
+//                     $schema: 'http://json-schema.org/draft-07/schema#',
+//                     title: 'no authority role',
+//                     type: 'boolean',
+//                     // prettier-ignore
+//                     const:
+//                 ['and',
+//                     ['==', '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over', true],
+//                     ['==', '$.answers.p-applicant-can-handle-affairs.q-applicant-capable', false],
+//                     ['==', '$.answers.p--has-legal-authority.q--has-legal-authority', false],
+//                     ['==', '$.answers.p--represents-legal-authority.q--represents-legal-authority', false]
+//                 ],
+//                     examples: [{}],
+//                     invalidExamples: [{}]
+//                 }
+//             },
+//             incapable: {
+//                 schema: {
+//                     $schema: 'http://json-schema.org/draft-07/schema#',
+//                     title: 'incapable role',
+//                     type: 'boolean',
+//                     // prettier-ignore
+//                     const:  ['==', '$.answers.p-applicant-can-handle-affairs.q-applicant-capable', false],
+//                     examples: [{}],
+//                     invalidExamples: [{}]
+//                 }
+//             },
+//             capable: {
+//                 schema: {
+//                     $schema: 'http://json-schema.org/draft-07/schema#',
+//                     title: 'capable role',
+//                     type: 'boolean',
+//                     // prettier-ignore
+//                     const: ['or',
+//                 ['==', '$.answers.p-applicant-can-handle-affairs.q-applicant-capable', true],
+//                 ['==', '$.answers.p-applicant-who-are-you-applying-for.q-applicant-who-are-you-applying-for', 'myself']
+//             ],
+//                     examples: [{}],
+//                     invalidExamples: [{}]
+//                 }
+//             },
+//             authority: {
+//                 schema: {
+//                     $schema: 'http://json-schema.org/draft-07/schema#',
+//                     title: 'Legal authority role',
+//                     type: 'boolean',
+//                     // prettier-ignore
+//                     const: ['or',
+//                 ['==', '$.answers.p--has-legal-authority.q--has-legal-authority', true],
+//                 ['==', '$.answers.p--represents-legal-authority.q--represents-legal-authority', true]
+//             ],
+//                     examples: [true, false],
+//                     invalidExamples: [{}]
+//                 }
+//             },
+//             deceased: {
+//                 schema: {
+//                     $schema: 'http://json-schema.org/draft-07/schema#',
+//                     title: 'Deceased role',
+//                     type: 'boolean',
+//                     // prettier-ignore
+//                     const: ['==', '$.answers.p-applicant-fatal-claim.q-applicant-fatal-claim', true],
+//                     examples: [true, false],
+//                     invalidExamples: [{}]
+//                 }
+//             },
+//             nonDeceased: {
+//                 schema: {
+//                     $schema: 'http://json-schema.org/draft-07/schema#',
+//                     title: 'Non Deceased journey role',
+//                     type: 'boolean',
+//                     // prettier-ignore
+//                     const: ['==', '$.answers.p-applicant-fatal-claim.q-applicant-fatal-claim', false],
+//                     examples: [true, false],
+//                     invalidExamples: [{}]
+//                 }
+//             },
+//             childUnder12: {
+//                 schema: {
+//                     $schema: 'http://json-schema.org/draft-07/schema#',
+//                     title: 'child under the age of 12',
+//                     type: 'boolean',
+//                     // prettier-ignore
+//                     const: [
+//                 'dateCompare',
+//                 '$.answers.p-applicant-enter-your-date-of-birth.q-applicant-enter-your-date-of-birth', // this date ...
+//                 '<', // is less than ...
+//                 '-12', // 12 ...
+//                 'years' // years (before, due to the negative (-12) ...
+//                 // today's date (no second date given. defaults to today's date).
+//             ],
+//                     examples: [{}],
+//                     invalidExamples: [{}]
+//                 }
+//             },
+//             childOver12: {
+//                 schema: {
+//                     $schema: 'http://json-schema.org/draft-07/schema#',
+//                     title: 'child over the age of 12',
+//                     type: 'boolean',
+//                     // prettier-ignore
+//                     const:   [
+//                 'dateCompare',
+//                 '$.answers.p-applicant-enter-your-date-of-birth.q-applicant-enter-your-date-of-birth', // this date ...
+//                 '>=', // is greater than or equeal too ...
+//                 '-12', // 12 ...
+//                 'years' // years (before, due to the negative (-12) ...
+//                 // today's date (no second date given. defaults to today's date).
+//             ],
+//                     examples: [{}],
+//                     invalidExamples: [{}]
+//                 }
+//             },
+//             noContactMethod: {
+//                 schema: {
+//                     $schema: 'http://json-schema.org/draft-07/schema#',
+//                     title: 'has no email or text contact method',
+//                     type: 'boolean',
+//                     // prettier-ignore
+//                     const: ['or',
+//                 ['==', '$.answers.p-applicant-confirmation-method.q-applicant-confirmation-method', 'none'],
+//                 ['==', '$.answers.p-mainapplicant-confirmation-method.q-mainapplicant-confirmation-method', 'none'],
+//                 ['==', '$.answers.p-rep-confirmation-method.q-rep-confirmation-method', 'none']
+//             ],
+//                     examples: [{}],
+//                     invalidExamples: [{}]
+//                 }
+//             }
+//         }
+//     }
+// };
+// const roles = getAllRoleDefinitions(template);
+// const r = expandConditionExpression(
+//     [
+//         'and',
+//         ['!=', '$.answers.p-applicant-infections.q-applicant-infections', 'yes'],
+//         [
+//             'dateCompare',
+//             '$.answers.p-applicant-enter-your-date-of-birth.q-applicant-enter-your-date-of-birth', // this date ...
+//             '>', // is more than ...
+//             '-7', // 7 ...
+//             'years' // years (before, due to the negative (-7) ...
+//             // today's date (no second date given. defaults to today's date).
+//         ]
+//     ],
+//     roles
+// );
+// const noOr = splitOrExpressions(r);
+// console.log(JSON.stringify(r, null, 2));
+// console.log(JSON.stringify(noOr, null, 2));
+// const newThing = collateNotEqualToConditions([noOr], template);
+// console.log('done');
+// console.log(JSON.stringify(newThing, null, 2));
+
+module.exports = ensureAllConditionsAreSatisfiable;

--- a/validators/ensureAllConditionsAreSatisfiable/index.test.js
+++ b/validators/ensureAllConditionsAreSatisfiable/index.test.js
@@ -1,0 +1,192 @@
+'use strict';
+
+const ensureAllConditionsAreSatisfiable = require('./index');
+const rolesSchema = require('./fixtures/questionnaire-schema-roles');
+
+describe('ensureAllConditionsAreSatisfiable', () => {
+    it('should return true if all conditions on a section are satisfiable', () => {
+        const validTemplate = {
+            sections: {
+                foo: {},
+                bar: {},
+                baz: {},
+                biz: {}
+            },
+            routes: {
+                initial: 'foo',
+                states: {
+                    foo: {
+                        on: {
+                            ANSWER: [
+                                {target: 'bar', cond: ['==', '$.answers.foo.q-foo', true]},
+                                {target: 'baz', cond: ['==', '$.answers.foo.q-foo', false]}
+                            ]
+                        }
+                    },
+                    bar: {
+                        on: {
+                            ANSWER: [{target: 'baz'}]
+                        }
+                    },
+                    baz: {
+                        on: {
+                            ANSWER: [{target: 'biz'}]
+                        }
+                    },
+                    biz: {
+                        type: 'final'
+                    }
+                }
+            },
+            attributes: rolesSchema.attributes
+        };
+        const validTemplate2 = {
+            sections: {
+                one: {},
+                two: {},
+                three: {},
+                four: {},
+                five: {},
+                six: {},
+                seven: {},
+                eight: {},
+                nine: {}
+            },
+            routes: {
+                initial: 'one',
+                states: {
+                    one: {
+                        on: {
+                            ANSWER: [
+                                {target: 'two', cond: ['==', '$.answers.one.q-one', true]},
+                                {target: 'three', cond: ['==', '$.answers.one.q-one', false]}
+                            ]
+                        }
+                    },
+                    two: {
+                        on: {
+                            ANSWER: [{target: 'four'}]
+                        }
+                    },
+                    three: {
+                        on: {
+                            ANSWER: [{target: 'four'}]
+                        }
+                    },
+                    four: {
+                        on: {
+                            ANSWER: [
+                                {target: 'five', cond: ['==', '$.answers.four.q-four', true]},
+                                {target: 'six', cond: ['==', '$.answers.four.q-four', false]}
+                            ]
+                        }
+                    },
+                    five: {
+                        on: {
+                            ANSWER: [
+                                {target: 'eight', cond: ['==', '$.answers.one.q-one', true]},
+                                {target: 'nine', cond: ['==', '$.answers.one.q-one', false]}
+                            ]
+                        }
+                    },
+                    six: {
+                        on: {
+                            ANSWER: [{target: 'seven'}]
+                        }
+                    },
+                    seven: {
+                        type: 'final'
+                    },
+                    eight: {
+                        type: 'final'
+                    },
+                    nine: {
+                        type: 'final'
+                    }
+                }
+            },
+            attributes: rolesSchema.attributes
+        };
+        expect(ensureAllConditionsAreSatisfiable(validTemplate)).toEqual(true);
+        expect(ensureAllConditionsAreSatisfiable(validTemplate2)).toEqual(true);
+    });
+
+    // need valid and invalid template for each question type
+
+    it('should return an error for each condition that is not satisfiable', () => {
+        const invalidTemplate = {
+            sections: {
+                foo: {},
+                bar: {},
+                baz: {},
+                biz: {}
+            },
+            routes: {
+                initial: 'bar',
+                states: {
+                    foo: {
+                        on: {
+                            ANSWER: [
+                                {target: 'bar', cond: ['==', '$.answers.foo.q-foo', true]},
+                                {target: 'baz', cond: ['==', '$.answers.foo.q-foo', false]}
+                            ]
+                        }
+                    },
+                    bar: {
+                        on: {
+                            ANSWER: [{target: 'baz', cond: ['==', '$.answers.foo.q-foo', false]}]
+                        }
+                    },
+                    baz: {
+                        on: {
+                            ANSWER: [{target: 'biz'}]
+                        }
+                    },
+                    biz: {
+                        type: 'final'
+                    }
+                }
+            },
+            attributes: rolesSchema.attributes
+        };
+        expect(ensureAllConditionsAreSatisfiable(invalidTemplate)).toThrow();
+    });
+
+    it('should ignore specified sections', () => {
+        const invalidTemplate = {
+            sections: {
+                foo: {},
+                bar: {},
+                baz: {},
+                biz: {}
+            },
+            routes: {
+                initial: 'bar',
+                states: {
+                    bar: {
+                        on: {
+                            ANSWER: [{target: 'biz'}]
+                        }
+                    },
+                    biz: {
+                        type: 'final'
+                    }
+                }
+            }
+        };
+        const errors = ensureAllSectionsAreTargetedByRouteTarget({
+            template: invalidTemplate,
+            sectionIdIgnoreList: ['foo']
+        });
+        const expectedErrors = [
+            {
+                type: 'UntargetedSection',
+                source: '/sections/baz',
+                description: `Section '/sections/baz' is not targeted by any route`
+            }
+        ];
+
+        expectedErrors.forEach(expectedError => expect(errors).toContainEqual(expectedError));
+        expect(errors.length).toEqual(expectedErrors.length);
+    });
+});

--- a/validators/ensureAllConditionsAreSatisfiable/index.test.js
+++ b/validators/ensureAllConditionsAreSatisfiable/index.test.js
@@ -4,189 +4,890 @@ const ensureAllConditionsAreSatisfiable = require('./index');
 const rolesSchema = require('./fixtures/questionnaire-schema-roles');
 
 describe('ensureAllConditionsAreSatisfiable', () => {
-    it('should return true if all conditions on a section are satisfiable', () => {
-        const validTemplate = {
-            sections: {
-                foo: {},
-                bar: {},
-                baz: {},
-                biz: {}
-            },
-            routes: {
-                initial: 'foo',
-                states: {
-                    foo: {
-                        on: {
-                            ANSWER: [
-                                {target: 'bar', cond: ['==', '$.answers.foo.q-foo', true]},
-                                {target: 'baz', cond: ['==', '$.answers.foo.q-foo', false]}
-                            ]
+    describe('Satisfiable conditions', () => {
+        it('should return true if all conditions on a section are satisfiable by questions on just that page', () => {
+            const validTemplate = {
+                routes: {
+                    initial: 'foo',
+                    states: {
+                        foo: {
+                            on: {
+                                ANSWER: [
+                                    {target: 'bar', cond: ['==', '$.answers.foo.q-foo', true]},
+                                    {target: 'baz', cond: ['==', '$.answers.foo.q-foo', false]}
+                                ]
+                            }
+                        },
+                        bar: {
+                            on: {
+                                ANSWER: [{target: 'baz'}]
+                            }
+                        },
+                        baz: {
+                            on: {
+                                ANSWER: [{target: 'biz'}]
+                            }
+                        },
+                        biz: {
+                            type: 'final'
                         }
-                    },
-                    bar: {
-                        on: {
-                            ANSWER: [{target: 'baz'}]
-                        }
-                    },
-                    baz: {
-                        on: {
-                            ANSWER: [{target: 'biz'}]
-                        }
-                    },
-                    biz: {
-                        type: 'final'
                     }
-                }
-            },
-            attributes: rolesSchema.attributes
-        };
-        const validTemplate2 = {
-            sections: {
-                one: {},
-                two: {},
-                three: {},
-                four: {},
-                five: {},
-                six: {},
-                seven: {},
-                eight: {},
-                nine: {}
-            },
-            routes: {
-                initial: 'one',
-                states: {
-                    one: {
-                        on: {
-                            ANSWER: [
-                                {target: 'two', cond: ['==', '$.answers.one.q-one', true]},
-                                {target: 'three', cond: ['==', '$.answers.one.q-one', false]}
-                            ]
-                        }
-                    },
-                    two: {
-                        on: {
-                            ANSWER: [{target: 'four'}]
-                        }
-                    },
-                    three: {
-                        on: {
-                            ANSWER: [{target: 'four'}]
-                        }
-                    },
-                    four: {
-                        on: {
-                            ANSWER: [
-                                {target: 'five', cond: ['==', '$.answers.four.q-four', true]},
-                                {target: 'six', cond: ['==', '$.answers.four.q-four', false]}
-                            ]
-                        }
-                    },
-                    five: {
-                        on: {
-                            ANSWER: [
-                                {target: 'eight', cond: ['==', '$.answers.one.q-one', true]},
-                                {target: 'nine', cond: ['==', '$.answers.one.q-one', false]}
-                            ]
-                        }
-                    },
-                    six: {
-                        on: {
-                            ANSWER: [{target: 'seven'}]
-                        }
-                    },
-                    seven: {
-                        type: 'final'
-                    },
-                    eight: {
-                        type: 'final'
-                    },
-                    nine: {
-                        type: 'final'
-                    }
-                }
-            },
-            attributes: rolesSchema.attributes
-        };
-        expect(ensureAllConditionsAreSatisfiable(validTemplate)).toEqual(true);
-        expect(ensureAllConditionsAreSatisfiable(validTemplate2)).toEqual(true);
-    });
-
-    // need valid and invalid template for each question type
-
-    it('should return an error for each condition that is not satisfiable', () => {
-        const invalidTemplate = {
-            sections: {
-                foo: {},
-                bar: {},
-                baz: {},
-                biz: {}
-            },
-            routes: {
-                initial: 'bar',
-                states: {
-                    foo: {
-                        on: {
-                            ANSWER: [
-                                {target: 'bar', cond: ['==', '$.answers.foo.q-foo', true]},
-                                {target: 'baz', cond: ['==', '$.answers.foo.q-foo', false]}
-                            ]
-                        }
-                    },
-                    bar: {
-                        on: {
-                            ANSWER: [{target: 'baz', cond: ['==', '$.answers.foo.q-foo', false]}]
-                        }
-                    },
-                    baz: {
-                        on: {
-                            ANSWER: [{target: 'biz'}]
-                        }
-                    },
-                    biz: {
-                        type: 'final'
-                    }
-                }
-            },
-            attributes: rolesSchema.attributes
-        };
-        expect(ensureAllConditionsAreSatisfiable(invalidTemplate)).toThrow();
-    });
-
-    it('should ignore specified sections', () => {
-        const invalidTemplate = {
-            sections: {
-                foo: {},
-                bar: {},
-                baz: {},
-                biz: {}
-            },
-            routes: {
-                initial: 'bar',
-                states: {
-                    bar: {
-                        on: {
-                            ANSWER: [{target: 'biz'}]
-                        }
-                    },
-                    biz: {
-                        type: 'final'
-                    }
-                }
-            }
-        };
-        const errors = ensureAllSectionsAreTargetedByRouteTarget({
-            template: invalidTemplate,
-            sectionIdIgnoreList: ['foo']
+                },
+                attributes: rolesSchema.attributes
+            };
+            expect(ensureAllConditionsAreSatisfiable(validTemplate)).toEqual(true);
         });
-        const expectedErrors = [
-            {
-                type: 'UntargetedSection',
-                source: '/sections/baz',
-                description: `Section '/sections/baz' is not targeted by any route`
-            }
-        ];
+        it('should return true if all conditions are simple and satisfiable', () => {
+            const validTemplate = {
+                sections: {
+                    one: {},
+                    two: {},
+                    three: {},
+                    four: {},
+                    five: {}
+                },
+                routes: {
+                    initial: 'one',
+                    states: {
+                        one: {
+                            on: {
+                                ANSWER: [
+                                    {target: 'two', cond: ['==', '$.answers.one.q-one', true]},
+                                    {target: 'three', cond: ['==', '$.answers.one.q-one', false]}
+                                ]
+                            }
+                        },
+                        two: {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'four',
+                                        cond: ['includes', '$.answers.two.q-two', 'true']
+                                    },
+                                    {
+                                        target: 'three',
+                                        cond: ['includes', '$.answers.two.q-two', 'false']
+                                    }
+                                ]
+                            }
+                        },
+                        three: {
+                            on: {
+                                ANSWER: [{target: 'four'}]
+                            }
+                        },
+                        four: {
+                            on: {
+                                ANSWER: [
+                                    {target: 'five', cond: ['==', '$.answers.four.q-four', true]},
+                                    {target: 'six', cond: ['==', '$.answers.four.q-four', false]}
+                                ]
+                            }
+                        }
+                    }
+                },
+                attributes: rolesSchema.attributes
+            };
+            expect(ensureAllConditionsAreSatisfiable(validTemplate)).toEqual(true);
+        });
+        it('should return true if all conditions with an OR are all satisfiable', () => {
+            const validTemplate = {
+                sections: {
+                    one: {},
+                    two: {},
+                    three: {},
+                    four: {},
+                    five: {}
+                },
+                routes: {
+                    initial: 'one',
+                    states: {
+                        one: {
+                            on: {
+                                ANSWER: [
+                                    {target: 'two', cond: ['==', '$.answers.one.q-one', true]},
+                                    {target: 'three', cond: ['==', '$.answers.one.q-one', false]}
+                                ]
+                            }
+                        },
+                        two: {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'four',
+                                        cond: ['includes', '$.answers.two.q-two', 'true']
+                                    },
+                                    {
+                                        target: 'three',
+                                        cond: ['includes', '$.answers.two.q-two', 'false']
+                                    }
+                                ]
+                            }
+                        },
+                        three: {
+                            on: {
+                                ANSWER: [{target: 'four'}]
+                            }
+                        },
+                        four: {
+                            on: {
+                                ANSWER: [
+                                    {target: 'five', cond: ['==', '$.answers.four.q-four', true]},
+                                    {target: 'six', cond: ['==', '$.answers.four.q-four', false]}
+                                ]
+                            }
+                        },
+                        five: {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'eight',
+                                        cond: [
+                                            'or',
+                                            ['includes', '$.answers.two.q-two', 'true'],
+                                            ['==', '$.answers.one.q-one', false]
+                                        ]
+                                    },
+                                    {target: 'nine', cond: ['==', '$.answers.one.q-one', false]}
+                                ]
+                            }
+                        }
+                    }
+                },
+                attributes: rolesSchema.attributes
+            };
+            expect(ensureAllConditionsAreSatisfiable(validTemplate)).toEqual(true);
+        });
+        it('should return true if all conditions with an AND are all satisfiable', () => {
+            const validTemplate = {
+                sections: {
+                    one: {},
+                    two: {},
+                    three: {},
+                    four: {},
+                    five: {}
+                },
+                routes: {
+                    initial: 'one',
+                    states: {
+                        one: {
+                            on: {
+                                ANSWER: [
+                                    {target: 'two', cond: ['==', '$.answers.one.q-one', true]},
+                                    {target: 'three', cond: ['==', '$.answers.one.q-one', false]}
+                                ]
+                            }
+                        },
+                        two: {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'four',
+                                        cond: ['includes', '$.answers.two.q-two', 'true']
+                                    },
+                                    {
+                                        target: 'three',
+                                        cond: ['includes', '$.answers.two.q-two', 'false']
+                                    }
+                                ]
+                            }
+                        },
+                        three: {
+                            on: {
+                                ANSWER: [{target: 'four'}]
+                            }
+                        },
+                        four: {
+                            on: {
+                                ANSWER: [
+                                    {target: 'five', cond: ['==', '$.answers.four.q-four', true]},
+                                    {target: 'six', cond: ['==', '$.answers.four.q-four', false]}
+                                ]
+                            }
+                        },
+                        five: {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'eight',
+                                        cond: [
+                                            'and',
+                                            ['includes', '$.answers.two.q-two', 'true'],
+                                            ['==', '$.answers.one.q-one', true]
+                                        ]
+                                    },
+                                    {target: 'nine', cond: ['==', '$.answers.one.q-one', false]}
+                                ]
+                            }
+                        }
+                    }
+                },
+                attributes: rolesSchema.attributes
+            };
+            expect(ensureAllConditionsAreSatisfiable(validTemplate)).toEqual(true);
+        });
+        it('should return true if a condition depends on a role for which only one condition is satisfiable', () => {
+            const validTemplate = {
+                routes: {
+                    // need to add in each of the pages referenced by the rep condition to show they're valid
+                    initial: 'p-applicant-who-are-you-applying-for',
+                    states: {
+                        'p-applicant-who-are-you-applying-for': {
+                            on: {
+                                ANSWER: [{target: 'p-applicant-are-you-18-or-over'}]
+                            }
+                        },
+                        'p-applicant-are-you-18-or-over': {
+                            on: {
+                                ANSWER: [{target: 'p-mainapplicant-parent'}]
+                            }
+                        },
+                        'p-mainapplicant-parent': {
+                            on: {
+                                ANSWER: [{target: 'p--has-legal-authority'}]
+                            }
+                        },
+                        'p--has-legal-authority': {
+                            on: {
+                                ANSWER: [{target: 'p-applicant-can-handle-affairs'}]
+                            }
+                        },
+                        'p-applicant-can-handle-affairs': {
+                            on: {
+                                ANSWER: [{target: 'foo'}]
+                            }
+                        },
+                        foo: {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'bar',
+                                        cond: [
+                                            'and',
+                                            [
+                                                '==',
+                                                '$.answers.p-applicant-who-are-you-applying-for.q-applicant-who-are-you-applying-for',
+                                                'someone-else'
+                                            ],
+                                            [
+                                                '==',
+                                                '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over',
+                                                false
+                                            ],
+                                            [
+                                                '==',
+                                                '$.answers.p-mainapplicant-parent.q-mainapplicant-parent',
+                                                false
+                                            ],
+                                            [
+                                                '==',
+                                                '$.answers.p--has-legal-authority.q--has-legal-authority',
+                                                false
+                                            ],
+                                            [
+                                                '==',
+                                                '$.answers.p-applicant-can-handle-affairs.q-applicant-capable',
+                                                false
+                                                // This conflicts with one of the definitions of what a rep is
+                                            ]
+                                        ]
+                                    },
+                                    {target: 'baz', cond: ['==', '$.answers.foo.q-foo', false]}
+                                ]
+                            }
+                        },
+                        bar: {
+                            on: {
+                                ANSWER: [{target: 'baz', cond: ['|role.all', 'rep']}]
+                            }
+                        },
+                        baz: {
+                            on: {
+                                ANSWER: [{target: 'biz'}]
+                            }
+                        },
+                        biz: {
+                            type: 'final'
+                        }
+                    }
+                },
+                attributes: rolesSchema.attributes
+            };
+            expect(ensureAllConditionsAreSatisfiable(validTemplate)).toEqual(true);
+        });
+        it('should return true if both roles are satisfied for a route containing different role options', () => {
+            const validTemplate = {
+                routes: {
+                    // need to add in each of the pages referenced by the rep condition to show they're valid
+                    initial: 'p-applicant-who-are-you-applying-for',
+                    states: {
+                        'p-applicant-who-are-you-applying-for': {
+                            on: {
+                                ANSWER: [{target: 'p-applicant-are-you-18-or-over'}]
+                            }
+                        },
+                        'p-applicant-are-you-18-or-over': {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'p-mainapplicant-parent',
+                                        cond: [
+                                            '==',
+                                            '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over',
+                                            false
+                                        ]
+                                    },
+                                    {
+                                        target: 'p-applicant-fatal',
+                                        cond: [
+                                            '==',
+                                            '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over',
+                                            true
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        'p-applicant-fatal': {
+                            on: {
+                                ANSWER: [{target: 'bar'}]
+                            }
+                        },
+                        'p-mainapplicant-parent': {
+                            on: {
+                                ANSWER: [{target: 'p--has-legal-authority'}]
+                            }
+                        },
+                        'p--has-legal-authority': {
+                            on: {
+                                ANSWER: [{target: 'p-applicant-can-handle-affairs'}]
+                            }
+                        },
+                        'p-applicant-can-handle-affairs': {
+                            on: {
+                                ANSWER: [{target: 'foo'}]
+                            }
+                        },
+                        foo: {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'bar',
+                                        cond: [
+                                            'and',
+                                            [
+                                                '==',
+                                                '$.answers.p-applicant-who-are-you-applying-for.q-applicant-who-are-you-applying-for',
+                                                'someone-else'
+                                            ],
+                                            [
+                                                '==',
+                                                '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over',
+                                                false
+                                            ],
+                                            [
+                                                '==',
+                                                '$.answers.p-mainapplicant-parent.q-mainapplicant-parent',
+                                                false
+                                            ],
+                                            [
+                                                '==',
+                                                '$.answers.p--has-legal-authority.q--has-legal-authority',
+                                                false
+                                            ]
+                                        ]
+                                    },
+                                    {target: 'baz', cond: ['==', '$.answers.foo.q-foo', false]}
+                                ]
+                            }
+                        },
+                        bar: {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'baz',
+                                        cond: [
+                                            'or',
+                                            ['|role.all', 'rep', 'child'],
+                                            ['|role.all', 'deceased', 'adult']
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        baz: {
+                            on: {
+                                ANSWER: [{target: 'biz'}]
+                            }
+                        },
+                        biz: {
+                            type: 'final'
+                        }
+                    }
+                },
+                attributes: rolesSchema.attributes
+            };
+            expect(ensureAllConditionsAreSatisfiable(validTemplate)).toEqual(true);
+        });
+        it('should return true if a route condition is an OR of two complex roles', () => {
+            const validTemplate = {
+                routes: {
+                    // need to add in each of the pages referenced by the rep condition to show they're valid
+                    initial: 'p-applicant-who-are-you-applying-for',
+                    states: {
+                        'p-applicant-who-are-you-applying-for': {
+                            on: {
+                                ANSWER: [{target: 'p-applicant-are-you-18-or-over'}]
+                            }
+                        },
+                        'p-applicant-are-you-18-or-over': {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'p-mainapplicant-parent',
+                                        cond: [
+                                            '==',
+                                            '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over',
+                                            false
+                                        ]
+                                    },
+                                    {
+                                        target: 'p-applicant-fatal',
+                                        cond: [
+                                            '==',
+                                            '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over',
+                                            true
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        'p-mainapplicant-confirmation-method': {
+                            on: {
+                                ANSWER: [{target: 'bar'}]
+                            }
+                        },
+                        'p-mainapplicant-parent': {
+                            on: {
+                                ANSWER: [{target: 'p--has-legal-authority'}]
+                            }
+                        },
+                        'p--has-legal-authority': {
+                            on: {
+                                ANSWER: [{target: 'p-applicant-can-handle-affairs'}]
+                            }
+                        },
+                        'p-applicant-can-handle-affairs': {
+                            on: {
+                                ANSWER: [{target: 'foo'}]
+                            }
+                        },
+                        foo: {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'bar',
+                                        cond: [
+                                            'and',
+                                            [
+                                                '==',
+                                                '$.answers.p-applicant-who-are-you-applying-for.q-applicant-who-are-you-applying-for',
+                                                'someone-else'
+                                            ],
+                                            [
+                                                '==',
+                                                '$.answers.p-applicant-are-you-18-or-over.q-applicant-are-you-18-or-over',
+                                                false
+                                            ],
+                                            [
+                                                '==',
+                                                '$.answers.p-mainapplicant-parent.q-mainapplicant-parent',
+                                                false
+                                            ],
+                                            [
+                                                '==',
+                                                '$.answers.p--has-legal-authority.q--has-legal-authority',
+                                                false
+                                            ]
+                                        ]
+                                    },
+                                    {target: 'baz', cond: ['==', '$.answers.foo.q-foo', false]}
+                                ]
+                            }
+                        },
+                        bar: {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'baz',
+                                        cond: [
+                                            'or',
+                                            ['|role.all', 'rep'],
+                                            ['|role.all', 'noContactMethod']
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        baz: {
+                            on: {
+                                ANSWER: [{target: 'biz'}]
+                            }
+                        },
+                        biz: {
+                            type: 'final'
+                        }
+                    }
+                },
+                attributes: rolesSchema.attributes
+            };
+            expect(ensureAllConditionsAreSatisfiable(validTemplate)).toEqual(true);
+        });
+        it('should return true if there are no conflicts between != conditions and == conditions', () => {
+            const validTemplate = {
+                sections: {
+                    foo: {
+                        schema: {
+                            properties: {
+                                'q-foo': {
+                                    oneOf: [{const: 'a'}, {const: 'b'}, {const: 'c'}, {const: 'd'}]
+                                }
+                            }
+                        }
+                    }
+                },
+                routes: {
+                    initial: 'foo',
+                    states: {
+                        foo: {
+                            on: {
+                                ANSWER: [
+                                    {target: 'bar', cond: ['==', '$.answers.foo.q-foo', 'c']},
+                                    {target: 'baz', cond: ['==', '$.answers.foo.q-foo', 'a']}
+                                ]
+                            }
+                        },
+                        bar: {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'baz',
+                                        cond: [
+                                            'and',
+                                            ['!=', '$.answers.foo.q-foo', 'a'],
+                                            ['!=', '$.answers.foo.q-foo', 'b']
+                                        ]
+                                    },
+                                    {target: 'biz'}
+                                ]
+                            }
+                        },
+                        baz: {
+                            on: {
+                                ANSWER: [{target: 'biz', cond: ['==', '$.answers.foo.q-foo', 'c']}]
+                            }
+                        }
+                    }
+                },
+                attributes: rolesSchema.attributes
+            };
+            expect(ensureAllConditionsAreSatisfiable(validTemplate)).toEqual(true);
+        });
+    });
+    // need valid and invalid template for each question type
+    // includes
+    // roles (including ands and ors of two complex roles)
+    // datecompare (simple cases where they have the same reference and also more complex ones (e.g. >5 and >6, <5 and <4))
+    // date difference greater than 2 days (currently broken)
+    // ors (for valid just any two conditions, for invalid need to do an or where one works and one doesn't )
+    // or of no contact method and rep if possible
 
-        expectedErrors.forEach(expectedError => expect(errors).toContainEqual(expectedError));
-        expect(errors.length).toEqual(expectedErrors.length);
+    describe('Unsatisfiable conditions', () => {
+        it('should throw an error if a route directly contradicts a route to that page', () => {
+            const invalidTemplate = {
+                sections: {
+                    foo: {},
+                    bar: {},
+                    baz: {},
+                    biz: {}
+                },
+                routes: {
+                    initial: 'foo',
+                    states: {
+                        foo: {
+                            on: {
+                                ANSWER: [
+                                    {target: 'bar', cond: ['==', '$.answers.foo.q-foo', true]},
+                                    {target: 'baz', cond: ['==', '$.answers.foo.q-foo', false]}
+                                ]
+                            }
+                        },
+                        bar: {
+                            on: {
+                                ANSWER: [
+                                    {target: 'baz', cond: ['==', '$.answers.foo.q-foo', false]},
+                                    {target: 'biz'}
+                                ]
+                            }
+                        },
+                        baz: {
+                            on: {
+                                ANSWER: [{target: 'biz'}]
+                            }
+                        },
+                        biz: {
+                            type: 'final'
+                        }
+                    }
+                },
+                attributes: rolesSchema.attributes
+            };
+            expect(ensureAllConditionsAreSatisfiable(invalidTemplate)).toThrow();
+        });
+        it('should throw an error for each invalid route from a page', () => {
+            const invalidTemplate = {
+                sections: {
+                    foo: {},
+                    bar: {},
+                    baz: {},
+                    biz: {}
+                },
+                routes: {
+                    initial: 'foo',
+                    states: {
+                        foo: {
+                            on: {
+                                ANSWER: [
+                                    {target: 'bar', cond: ['==', '$.answers.foo.q-foo', true]},
+                                    {target: 'baz', cond: ['==', '$.answers.foo.q-foo', false]}
+                                ]
+                            }
+                        },
+                        bar: {
+                            on: {
+                                ANSWER: [
+                                    {target: 'baz', cond: ['==', '$.answers.foo.q-foo', false]},
+                                    {
+                                        target: 'biz',
+                                        cond: ['==', '$.answers.foo.q-foo', 'undefined']
+                                    }
+                                ]
+                            }
+                        },
+                        baz: {
+                            on: {
+                                ANSWER: [{target: 'biz'}]
+                            }
+                        },
+                        biz: {
+                            type: 'final'
+                        }
+                    }
+                },
+                attributes: rolesSchema.attributes
+            };
+            expect(ensureAllConditionsAreSatisfiable(invalidTemplate)).toThrow();
+        });
+        it('should throw an error if not all OR conditions on a route can be satisfied', () => {
+            const invalidTemplate = {
+                sections: {
+                    one: {},
+                    two: {},
+                    three: {},
+                    four: {},
+                    five: {}
+                },
+                routes: {
+                    initial: 'one',
+                    states: {
+                        one: {
+                            on: {
+                                ANSWER: [
+                                    {target: 'two', cond: ['==', '$.answers.one.q-one', true]},
+                                    {target: 'three', cond: ['==', '$.answers.one.q-one', false]}
+                                ]
+                            }
+                        },
+                        two: {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'four',
+                                        cond: ['includes', '$.answers.two.q-two', 'true']
+                                    },
+                                    {
+                                        target: 'three',
+                                        cond: ['includes', '$.answers.two.q-two', 'false']
+                                    }
+                                ]
+                            }
+                        },
+                        three: {
+                            on: {
+                                ANSWER: [{target: 'four'}]
+                            }
+                        },
+                        four: {
+                            on: {
+                                ANSWER: [{target: 'five'}]
+                            }
+                        },
+                        five: {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'eight',
+                                        cond: [
+                                            'or',
+                                            ['includes', '$.answers.two.q-two', 'true'],
+                                            ['==', '$.answers.one.q-one', 'undefined']
+                                        ]
+                                    },
+                                    {target: 'nine', cond: ['==', '$.answers.one.q-one', false]}
+                                ]
+                            }
+                        }
+                    }
+                },
+                attributes: rolesSchema.attributes
+            };
+            expect(ensureAllConditionsAreSatisfiable(invalidTemplate)).toThrow();
+        });
+        it('should throw an error if not all conditions with an AND are all satisfiable', () => {
+            const validTemplate = {
+                sections: {
+                    one: {},
+                    two: {},
+                    three: {},
+                    four: {},
+                    five: {}
+                },
+                routes: {
+                    initial: 'one',
+                    states: {
+                        one: {
+                            on: {
+                                ANSWER: [
+                                    {target: 'two', cond: ['==', '$.answers.one.q-one', true]},
+                                    {target: 'three', cond: ['==', '$.answers.one.q-one', false]}
+                                ]
+                            }
+                        },
+                        two: {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'four',
+                                        cond: ['includes', '$.answers.two.q-two', 'true']
+                                    },
+                                    {
+                                        target: 'three',
+                                        cond: ['includes', '$.answers.two.q-two', 'false']
+                                    }
+                                ]
+                            }
+                        },
+                        three: {
+                            on: {
+                                ANSWER: [{target: 'four'}]
+                            }
+                        },
+                        four: {
+                            on: {
+                                ANSWER: [
+                                    {target: 'five', cond: ['==', '$.answers.four.q-four', true]},
+                                    {target: 'six', cond: ['==', '$.answers.four.q-four', false]}
+                                ]
+                            }
+                        },
+                        five: {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'eight',
+                                        cond: [
+                                            'and',
+                                            ['includes', '$.answers.two.q-two', 'true'],
+                                            ['==', '$.answers.one.q-one', true]
+                                        ]
+                                    },
+                                    {target: 'nine', cond: ['==', '$.answers.one.q-one', false]}
+                                ]
+                            }
+                        }
+                    }
+                },
+                attributes: rolesSchema.attributes
+            };
+            expect(ensureAllConditionsAreSatisfiable(validTemplate)).toEqual(true);
+        });
+        it('should throw an error if there is a conflict between != conditions', () => {
+            const invalidTemplate = {
+                sections: {
+                    foo: {
+                        schema: {
+                            properties: {
+                                'q-foo': {
+                                    oneOf: [{const: 'a'}, {const: 'b'}, {const: 'c'}, {const: 'd'}]
+                                }
+                            }
+                        }
+                    }
+                },
+                routes: {
+                    initial: 'foo',
+                    states: {
+                        foo: {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'bar',
+                                        cond: [
+                                            'or',
+                                            ['==', '$.answers.foo.q-foo', 'c'],
+                                            ['==', '$.answers.foo.q-foo', 'd']
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        bar: {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'baz',
+                                        cond: [
+                                            'and',
+                                            ['!=', '$.answers.foo.q-foo', 'a'],
+                                            ['!=', '$.answers.foo.q-foo', 'b']
+                                        ]
+                                    },
+                                    {target: 'biz'}
+                                ]
+                            }
+                        },
+                        baz: {
+                            on: {
+                                ANSWER: [
+                                    {
+                                        target: 'biz',
+                                        cond: [
+                                            'and',
+                                            ['!=', '$.answers.foo.q-foo', 'c'],
+                                            ['!=', '$.answers.foo.q-foo', 'd']
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        biz: {
+                            type: 'final'
+                        }
+                    }
+                },
+                attributes: rolesSchema.attributes
+            };
+            expect(ensureAllConditionsAreSatisfiable(invalidTemplate)).toThrow();
+        });
     });
 });

--- a/validators/ensureAllConditionsAreSatisfiable/index.test.js
+++ b/validators/ensureAllConditionsAreSatisfiable/index.test.js
@@ -593,6 +593,39 @@ describe('ensureAllConditionsAreSatisfiable', () => {
             };
             expect(ensureAllConditionsAreSatisfiable(validTemplate)).toEqual(true);
         });
+        it('should return true if the only route to a target is unconditional, but there are other conditional routes', () => {
+            const validTemplate = {
+                routes: {
+                    initial: 'foo',
+                    states: {
+                        foo: {
+                            on: {
+                                ANSWER: [
+                                    {target: 'bar', cond: ['==', '$.answers.foo.q-foo', true]},
+                                    {target: 'baz', cond: ['==', '$.answers.foo.q-foo', false]},
+                                    {target: 'biz'}
+                                ]
+                            }
+                        },
+                        bar: {
+                            on: {
+                                ANSWER: [{target: 'baz'}]
+                            }
+                        },
+                        baz: {
+                            on: {
+                                ANSWER: [{target: 'biz'}]
+                            }
+                        },
+                        biz: {
+                            type: 'final'
+                        }
+                    }
+                },
+                attributes: rolesSchema.attributes
+            };
+            expect(ensureAllConditionsAreSatisfiable(validTemplate)).toEqual(true);
+        });
     });
     // need valid and invalid template for each question type
     // includes


### PR DESCRIPTION
Adds a test to the validator that ensures all conditional routes leading from a section can be satisfied. This works by getting the route conditions (called preconditions in the code) for each section in turn and recursing backwards through the template via all sections that lead to that target section. At each previous section, if the preconditions evaluating to true would lead to a page other than the target, that path is marked as false. If they would lead to the desired page, the routing continues until we have hit each page referenced in the precondition. If any path is successfully found, the route must therefore be satisfiable.

The logic for adding this test is that if we can ensure all routes are satisfiable, our BDD tests no longer need to go through the entire application; we can just setup a router object with the desired answers and ensure that specific functionality is correct. This is because if the test here validates that that route can be reached, the BDD only needs to check the actual behaviour (i.e. that the routes go to the right place). This will make maintaining the BDDs much simpler, although we can still keep longer BDDs for specific routes/roles if desired as well.
